### PR TITLE
Add toggle for battery support

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -101,6 +101,14 @@
         "type": "string",
         "required": false,
         "description": "Override the builtin myQ application identifier when connecting to the myQ API. Use with extreme caution."
+      },
+
+      "batteryStatus": {
+        "title": "Enable Battery Support",
+	"default": true,
+        "type": "boolean",
+        "required": false,
+        "description": "Enable displaying battery status."
       }
 
     }
@@ -173,7 +181,8 @@
             "activeRefreshInterval",
             "activeRefreshDuration",
             "debug",
-            "appId"
+            "appId",
+            "batteryStatus"
           ]
         }
       ]

--- a/docs/AdvancedOptions.md
+++ b/docs/AdvancedOptions.md
@@ -30,6 +30,7 @@ This step is not required. The defaults should work well for almost everyone, bu
     "activeRefreshInterval": 3,
     "activeRefreshDuration": 300,
     "appId": "abcdefg",
+    "batteryStatus": true,
     "options": ["Hide.GW12345", "Show.CG6789"],
     "mqttUrl": "mqtt:1.2.3.4",
     "mqttTopic": "myq",
@@ -48,6 +49,7 @@ This step is not required. The defaults should work well for almost everyone, bu
 | activeRefreshInterval | Refresh interval in `seconds` to use when myQ device state changes are detected.   | 3       | No       |
 | activeRefreshDuration | Duration in `seconds` to use `activeRefreshInterval` to refresh myQ device status. | 300     | No       |
 | appId                 | Override the builtin myQ appId to a user supplied one. **Use with extreme care.**  | false   | No       |
+| batteryStatus         | Enable support for battery status.                                                 | true    | No       |
 | options               | Configure plugin [feature options](https://github.com/hjdhjd/homebridge-myq/blob/master/docs/FeatureOptions.md).  | []      | No       |
 | mqttUrl               | The URL of your MQTT broker. **This must be in URL form**, e.g.: `mqtt://user@password:1.2.3.4`. |      | No       |
 | mqttTopic             | The base topic to use when publishing MQTT messages.                               | "myq"   | No       |

--- a/src/myq-garagedoor.ts
+++ b/src/myq-garagedoor.ts
@@ -86,6 +86,11 @@ export class myQGarageDoor extends myQAccessory {
   // Configure the battery status information for HomeKit.
   private configureBatteryInfo(): boolean {
 
+    if(!this.config.batteryStatus) {
+      this.log.info("Support for battery status is disabled.")
+      return false;
+    }
+
     // If we don't have a door position sensor, we're done.
     if(this.doorPositionSensorBatteryStatus() === -1) {
       return false;

--- a/src/myq-platform.ts
+++ b/src/myq-platform.ts
@@ -63,6 +63,7 @@ export class myQPlatform implements DynamicPlatformPlugin {
       activeRefreshDuration: "activeRefreshDuration" in config ? parseInt(config.activeRefreshDuration as string) : MYQ_ACTIVE_DEVICE_REFRESH_DURATION,
       activeRefreshInterval: "activeRefreshInterval" in config ? parseInt(config.activeRefreshInterval as string) : MYQ_ACTIVE_DEVICE_REFRESH_INTERVAL,
       appId: "appId" in config ? config.appId as string : MYQ_API_APPID,
+      batteryStatus: config.batteryStatus == true,
       debug: config.debug === true,
       email: config.email as string,
       mqttTopic: "mqttTopic" in config ? config.mqttTopic as string : MYQ_MQTT_TOPIC,

--- a/src/myq-types.ts
+++ b/src/myq-types.ts
@@ -155,6 +155,7 @@ export interface myQOptionsInterface {
   activeRefreshDuration: number,
   activeRefreshInterval: number,
   appId: string,
+  batteryStatus: boolean,
   debug: boolean,
   email: string,
   mqttTopic: string,


### PR DESCRIPTION
Battery level support is extremely buggy on the device side: after replacing a battery the "low battery" warning never goes away despite following the instructions at:

https://support.chamberlaingroup.com/s/article/myQ-App-Displays-Low-Battery

This PR makes battery support optional (enabled by default) to deal with this.