### PR TITLE
Add simple token refresh flow

### DIFF
--- a/src/myq-api.ts
+++ b/src/myq-api.ts
@@ -275,6 +275,7 @@ export class myQApi {
   private async simpleTokenRefresh(): Promise<boolean> {
 
     try {
+    
       // Create the request to get our access and refresh tokens.
       const requestBody = new URLSearchParams({
         "client_id": MYQ_API_CLIENT_ID,
@@ -304,7 +305,7 @@ export class myQApi {
       this.refreshToken = token.refresh_token;
       this.accessToken = token.token_type + " " + token.access_token;
       return true
-    } catch (error) {
+    } catch(error) {
       this.log.error("myQ API: Unable to use refresh token. Will retry full OAuth flow.");
       return false;
     }
@@ -377,8 +378,8 @@ export class myQApi {
       return true;
     }
 
-    //Try using the refresh token first
-    if (await this.simpleTokenRefresh()){
+    // Try using the refresh token before getting a new token.
+    if(await this.simpleTokenRefresh()){
       return true;
     }
 


### PR DESCRIPTION
Please disregard if this has already been considered or if I have overlooked something obvious.
While working through this code to factor into the SmartThings implementation (thank you again for this amazing code to work from), I found the need to be able to make repeated use of refresh tokens rather than go through the whole OAuth login process from the beginning each time.

I thought I would share this in case it was useful to add an attempt to refresh the access token in this way - an option to keep things simpler and avoid some of the http redirecting and cookie parsing some of the time. I realize there are probably cleaner ways to work it in as well, but hopefully it's enough to outline the concept.