### PR TITLE
Prevent 'Target Door State' characteristic set handler warning

### DIFF
--- a/src/myq-garagedoor.ts
+++ b/src/myq-garagedoor.ts
@@ -60,7 +60,9 @@ export class myQGarageDoor extends myQAccessory {
       .updateCharacteristic(this.hap.Characteristic.CurrentDoorState, doorCurrentState)
       .updateCharacteristic(this.hap.Characteristic.TargetDoorState, doorTargetState)
       .getCharacteristic(this.hap.Characteristic.TargetDoorState)
-      .onSet(this.setDoorState.bind(this));
+      .onSet((value) => {
+        this.setDoorState(value);
+      });
 
     // Add all the events to our accessory so we can tell HomeKit our state.
     garagedoorService


### PR DESCRIPTION
Hey! Im not sure when it started but I noticed some errors in my logs when using the plugin, this addresses that. Yes, its a 1(-ish) line PR 🙂

Specifically I was getting:
```
[2/5/2022, 5:12:24 PM] [homebridge-myq] Characteristic 'Target Door State': SET handler returned write response value, though the characteristic doesn't support write response. See https://git.io/JtMGR for more info.
[2/5/2022, 5:12:24 PM] [homebridge-myq] Error: 
    at TargetDoorState.Characteristic.characteristicWarning (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:2142:105)
    at TargetDoorState.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1686:18)
    at step (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:143:27)
    at Object.next (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:124:57)
    at fulfilled (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:114:62)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
[2/5/2022, 5:12:35 PM] [myQ] Left Garage Door: Open.
[2/5/2022, 5:13:03 PM] [homebridge-myq] Characteristic 'Target Door State': SET handler returned write response value, though the characteristic doesn't support write response. See https://git.io/JtMGR for more info.
[2/5/2022, 5:13:03 PM] [homebridge-myq] Error: 
    at TargetDoorState.Characteristic.characteristicWarning (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:2142:105)
    at TargetDoorState.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1686:18)
    at step (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:143:27)
    at Object.next (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:124:57)
    at fulfilled (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:114:62)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
[2/5/2022, 5:13:37 PM] [myQ] Left Garage Door: Closed.
```

which points to the 'Target Door State' Characteristic `onSet` method, which [I believe in this case shouldn't return a value](https://developers.homebridge.io/HAP-NodeJS/classes/Characteristic.html#onSet). Since `setDoorState` does return a boolean, to prevent this I just wrap it in an anonymous method. No more warnings!