### PR TITLE
Added Feature Option to disable door sensor battery status detection

### DIFF
--- a/docs/FeatureOptions.md
+++ b/docs/FeatureOptions.md
@@ -23,6 +23,7 @@ The `options` setting is an array of strings used to customize feature options. 
 
 * <CODE>Disable.<I>serialnumber</I></CODE> - hide the opener or gateway identified by `serialnumber` from HomeKit.
 * <CODE>Enable.<I>serialnumber</I></CODE> - show the opener or gateway identified by `serialnumber` from HomeKit.
+* <CODE>Disable.BatteryStatus</CODE> - disables battery status detection on otherwise supported myQ door position sensor devices
 
 The plugin will log all devices it encounters and knows about, and you can use that to guide what you'd like to hide or show.
 

--- a/src/myq-garagedoor.ts
+++ b/src/myq-garagedoor.ts
@@ -101,6 +101,10 @@ export class myQGarageDoor extends myQAccessory {
   // Configure the battery status information for HomeKit.
   private configureBatteryInfo(): boolean {
 
+    // If we've explicitly disabled battery status in Feature Options, we're done
+    if(this.config.options.indexOf("Disable.BatteryStatus") !== -1) {
+      return false;
+    }
     // If we don't have a door position sensor, we're done.
     if(this.doorPositionSensorBatteryStatus() === -1) {
       return false;


### PR DESCRIPTION
- configureBatteryInfo first checks for <CODE>Disable.BatteryStatus</CODE> string in Plugin Feature Options before attempting to support Battery Status. If the string is present, it will not proceed to evaluate the door status sensor for support.
- Added description to Feature Options documentation