### PR TITLE
Add the ability to have a ReadOnly opener.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -135,7 +135,7 @@
           "type": "array",
           "orderable": true,
           "title": " ",
-          "description": "Feature options allow you to further customize the behavior of this plugin such as the ability to show or hide specific garage door openers.",
+          "description": "Feature options allow you to further customize the behavior of this plugin such as the ability to show or hide specific garage door openers. (one of the following: Enable.SerialNumber, Disable.SerialNumber, ReadOnly.SerialNumber)",
           "buttonText": "Add Feature Option",
           "items": [
             "options[]"

--- a/docs/FeatureOptions.md
+++ b/docs/FeatureOptions.md
@@ -23,8 +23,11 @@ The `options` setting is an array of strings used to customize feature options. 
 
 - `Disable.<your_serial_number>` - hide the opener or gateway identified by `<your_serial_number>` from HomeKit.
 - `Enable.<your_serial_number>` - show the opener or gateway identified by `<your_serial_number>` from HomeKit.
+- `ReadOnly.<your_serial_number>` - Reject open/close requests of the opener identified by `<your_serial_number>` from HomeKit.
 
-With both the `Disable` and `Enable` options, replace `<your_serial_number>` with the serial number for your specific device found within the device "Accessory Details" in the Home app.
+With the `ReadOnly`, `Disable` and `Enable` options, replace `<your_serial_number>` with the serial number for your specific device found within the device "Accessory Details" in the Home app.
+
+The `ReadOnly` option is intended to only allow queries of the status of an opener via HomeKit and not operate it for security purposes.
 
 The plugin will log all devices it encounters and knows about, and you can use that to guide what you'd like to hide or show.
 

--- a/src/myq-garagedoor.ts
+++ b/src/myq-garagedoor.ts
@@ -199,6 +199,11 @@ export class myQGarageDoor extends myQAccessory {
     const accessory = this.accessory;
     const hap = this.hap;
 
+    // No state changes are permitted for this opener
+    if(this.config.options.indexOf("ReadOnly." + this.accessory.context.device.serial_number) !== -1) {
+      return false;
+    }
+
     if(myQState === -1) {
       //new Error("Unable to determine the current door state."));
       return false;


### PR DESCRIPTION
For security purposes the end user may not want to allow any kind of voice command which can operate an opener.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>